### PR TITLE
PostgreSQL を docker コンテナとして起動する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+DATABASE_URL=jdbc:postgresql://localhost:5432/tabisketch
+DATABASE_USERNAME=postgres
+DATABASE_PASSWORD=postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=tabisketch
+MAIL_USERNAME=test@example.com
+MAIL_PASSWORD=dummy
+GOOGLE_MAPS_API_KEY=dummy

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ build/
 
 ### Tailwind CSS ###
 **/src/main/**/css/tailwind.css
+
+
+### dot env file ###
+.env*
+!/.env.example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  postgresql:
+    image: postgres:16
+    container_name: postgresql
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./docker/postgresql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./.run:/docker-entrypoint-initdb.d/.run
+    env_file:
+      - .env
+    hostname: postgres
+    restart: always

--- a/docker/postgresql/docker-entrypoint-initdb.d/init_db.sh
+++ b/docker/postgresql/docker-entrypoint-initdb.d/init_db.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# シェルスクリプトのディレクトリを取得
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Create Tables
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreateUsersTable.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreatePasswordResetTokensTable.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreateMailAddressAuthTokensTable.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreatePlansTable.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreateDaysTable.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreateGooglePlacesTable.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreateGooglePlaceTypesTable.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreateGoogleTypeAssociationsTable.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreateTransportationsType.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreatePlacesTable.sql"
+psql -U postgres -d tabisketch -f "$SCRIPT_DIR/.run/sql/CreatePackingsTable.sql"


### PR DESCRIPTION
## 概要

- PostgreSQL を コンテナで起動する
- docker compose を使って、コンテナの起動と停止を操作する


## テーブルの作成と削除、初期データについて

- `docker compose up` でコンテナを起動すると、postgresql の `docker-entrypoint-initdb.d` 機能により、自動的に `./docker/postgresql/docker-entrypoint-initdb.d/init_db.sh` 経由で `./.run/sql` の中のsql ファイルが実行される
- `docker compose down` でコンテナを削除すると、テーブルが自動的に削除されるため、drop table が必要ない
- コンテナを起動すれば、いつでも初期状態のDBを手に入れることができる
- 開発用の初期データ (seedデータ) を作成するとよい (このコミットでは未実装)



## コミット内容

- sql の実行順が IntelliJ の xml ファイルへの記述順に依存していたため、実行順を明示的にするために、sqlのファイル名に数字を追加する
- 環境変数を .env ファイルで取り扱う
- docker compose の YAML ファイルを作成


## テスト

これで作成した postgresql コンテナを使ったテストを実行すると PASS する

```bash
DATABASE_URL='jdbc:postgresql://localhost:5432/tabisketch' \
DATABASE_USERNAME='postgres' \
DATABASE_PASSWORD='postgres' \
MAIL_USERNAME='test' \
MAIL_PASSWORD='test' \
GOOGLE_MAPS_API_KEY='dummy' \
sh ./mvnw package
```

<img width="772" alt="image" src="https://github.com/user-attachments/assets/57d8e8aa-54c2-4389-bb0d-6da9fb2c619e" />


