### PR TITLE
dependabot を追加して、ライブラリの更新PRを自動化する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "daily"
+      time: "07:30"
+      timezone: "Asia/Tokyo"
+  - package-ecosystem: "maven"
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "daily"
+      time: "07:30"
+      timezone: "Asia/Tokyo"
+  - package-ecosystem: "npm"
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "daily"
+      time: "07:30"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
## 概要
- dependabot を使って、ライブラリの更新を自動化する


## 作業内容
- Dependabotの設定ファイルを追加
- GitHub Actions、Maven、NPMの依存関係を毎日自動更新PRするようスケジュールを設定しました。
- 日本時間の午前7時30分頃に行われる

