### PR TITLE
ライブラリのバージョンを固定値で指定する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "flowbite": "^2.5.2",
-        "sortablejs": "^1.15.6",
-        "tailwind-hamburgers": "^1.3.5"
+        "flowbite": "2.5.2",
+        "sortablejs": "1.15.6",
+        "tailwind-hamburgers": "1.3.5"
       },
       "devDependencies": {
-        "@eslint/js": "^9.16.0",
-        "eslint": "^9.17.0",
-        "globals": "^15.14.0",
-        "tailwindcss": "^3.4.17"
+        "@eslint/js": "9.16.0",
+        "eslint": "9.17.0",
+        "globals": "15.14.0",
+        "tailwindcss": "3.4.17"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -185,10 +185,11 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
-      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
+      "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -921,6 +922,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
+      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@eslint/js": "^9.16.0",
-    "eslint": "^9.17.0",
-    "globals": "^15.14.0",
-    "tailwindcss": "^3.4.17"
+    "@eslint/js": "9.16.0",
+    "eslint": "9.17.0",
+    "globals": "15.14.0",
+    "tailwindcss": "3.4.17"
   },
   "dependencies": {
-    "flowbite": "^2.5.2",
-    "sortablejs": "^1.15.6",
-    "tailwind-hamburgers": "^1.3.5"
+    "flowbite": "2.5.2",
+    "sortablejs": "1.15.6",
+    "tailwind-hamburgers": "1.3.5"
   }
 }


### PR DESCRIPTION
## 関連する
- #220 

## 内容

npmライブラリのバージョン指定を `^`を使わずに数値に固定することにより、利用するバージョンの曖昧さを無くす。

## 例

```
"^9.16.0"
```

を

```
"9.16.0"
```

と固定値でバージョン指定する。

## メリット

dependabot も扱いやすくなる