### PR TITLE
パスワード変更確認通知ページの作成

### DIFF
--- a/src/main/resources/templates/user/edit/password/confirm.html
+++ b/src/main/resources/templates/user/edit/password/confirm.html
@@ -12,7 +12,7 @@
         <p class="my-2">セキュリティ上の理由から、再度ログインする必要があります。</p>
         <p class="my-2">続行ボタンをクリックして、ログイン画面にお進みください。</p>
     </div>
-    <button type="submit" class="button-primary" style="max-width: 7.375rem" onclick="location.href='/login'">続行</button>
+    <button type="button" class="button-primary" style="max-width: 7.375rem" onclick="location.href='/login'">続行</button>
 </main>
 <th:block th:replace="~{fragment/footer :: footer}"/>
 <th:block th:replace="~{fragment/script :: header}"/>

--- a/src/main/resources/templates/user/edit/password/confirm.html
+++ b/src/main/resources/templates/user/edit/password/confirm.html
@@ -1,10 +1,20 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
-パスワードを変更しました。
+<html lang="ja">
+<th:block th:replace="~{fragment/head :: head('パスワード変更完了')}"/>
+<body class="flex flex-col min-h-screen bg-gray-50">
+<th:block th:replace="~{fragment/header :: header}"/>
+<main class="flex flex-col items-center mt-10 flex-grow">
+    <h2 class="text-center sm:text-3xl text-lg font-medium text-default w-3/4">
+        パスワードが変更されました
+    </h2>
+    <div class="my-16 text-center sm:text-xl text-sm w-3/4">
+        <p class="my-2">パスワードの変更が完了しました。</p>
+        <p class="my-2">セキュリティ上の理由から、再度ログインする必要があります。</p>
+        <p class="my-2">続行ボタンをクリックして、ログイン画面にお進みください。</p>
+    </div>
+    <button type="submit" class="button-primary" style="max-width: 7.375rem" onclick="location.href='/login'">続行</button>
+</main>
+<th:block th:replace="~{fragment/footer :: footer}"/>
+<th:block th:replace="~{fragment/script :: header}"/>
 </body>
 </html>


### PR DESCRIPTION
## 概要
<!-- 以下にissueを記載 (close #xxx)-->
close なし

<!-- 以下にプルリクの内容を記載 -->
- 画面設計通り、ボタンの遷移先はログイン画面にしています。

### スクリーンショット
<!-- 以下にスクリーンショットを添付 -->
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/6d58914f-552d-477f-864f-f9c52e321170" />
