### PR TITLE
Playwrightでブラウザを自動操縦するE2Eテストの基本構造を作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ build/
 
 ### Tailwind CSS ###
 **/src/main/**/css/tailwind.css
+node_modules/
+
+### Playwright ###
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ GOOGLE_MAPS_API_KEY GoogleMapのAPIキー
 #### テーブル一括削除
 
 `.run/bin/DropTables.sh [PostgreSQLのユーザー名] [PostgreSQLのパスワード] tabisketch`
+
+#### PlaywrightによるE2Eテストの実行
+
+```bash
+npm run e2e
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.16.0",
+        "@playwright/test": "1.49.1",
+        "@types/node": "22.10.6",
         "eslint": "^9.17.0",
         "globals": "^15.14.0",
         "tailwindcss": "^3.4.17"
@@ -392,6 +394,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -472,6 +490,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
+      "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -1775,6 +1803,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.47",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
@@ -2333,6 +2408,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint src/**/*.js",
+    "e2e": "npx playwright test --project=chromium",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -12,6 +13,8 @@
   "license": "ISC",
   "devDependencies": {
     "@eslint/js": "^9.16.0",
+    "@playwright/test": "1.49.1",
+    "@types/node": "22.10.6",
     "eslint": "^9.17.0",
     "globals": "^15.14.0",
     "tailwindcss": "^3.4.17"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'dot',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/tests/settings.ts
+++ b/tests/settings.ts
@@ -1,0 +1,1 @@
+export const url = 'http://localhost:8080';

--- a/tests/top.spec.ts
+++ b/tests/top.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { url } from './settings'
+
+test('リダイレクト', async ({ page }) => {
+  // TOPページにアクセスする
+  await page.goto(url);
+
+  // http://localhost:8080/top にリダイレクトされる
+  await expect(page).toHaveURL(`${url}/top`);
+});
+
+test('タイトル', async ({ page }) => {
+  // TOPページにアクセスする
+  await page.goto(`${url}/top`);
+
+  // タイトルタグが 'トップ' であることを確認する
+  await expect(page).toHaveTitle('トップ');
+});
+
+test('ログインのnavリンク', async ({ page }) => {
+  // TOPページにアクセスする
+  await page.goto(`${url}/top`);
+
+  // ログインリンクが header > nav > ul > li:nth-child(1) に表示されていることを確認する
+  const loginLink = page.locator('header > nav > ul > li:nth-child(1) > a'); // 'a'タグの通常セレクタを使用
+  await expect(loginLink).toHaveText('ログイン');
+});
+
+test('新規登録のnavリンク', async ({ page }) => {
+  // TOPページにアクセスする
+  await page.goto(`${url}/top`);
+
+  // 新規登録リンクが header > nav > ul > li:nth-child(2) 表示されていることを確認する
+  const registerLink = page.locator('header > nav > ul > li:nth-child(2) > a'); // 'a'タグの通常セレクタを使用
+  await expect(registerLink).toHaveText('新規登録');
+});


### PR DESCRIPTION
## 概要

Playwrightでブラウザを自動操縦するE2Eテストの基本構造を作成

## 関連する
- #264 

<!-- 以下にプルリクの内容を記載 -->
- [x] playwrightのインストール 8006e6c65eead58812ffe1d48c4d1aee77f7c975
- [x] playwrightの設定ファイルの作成 5f96b14604a043997289f33627b73d19047ec404
- [x] TOPページテストの基本的なファイルを作成 7814c8bd97477f5dd3f498b3e4cdf9923e62dcb0
  - [x] `/` にアクセスすると `/top` にリダイレクトされる
  - [x] `header > nav > ul > li` に ログインと新規登録のリンクが存在する

