### PR TITLE
input.css の変更を検知して tailwind.css を自動でリビルドする docker コンテナの追加

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,14 @@ services:
     volumes:
       - ./postgresql/sql:/docker-entrypoint-initdb.d
     restart: always
+  tailwindcss:
+    container_name: tailwindcss
+    image: node:22-alpine
+    tty: true
+    working_dir: /app
+    volumes:
+      - ../:/app
+    command: sh -c "npx tailwindcss -i ./src/main/resources/static/css/input.css -o ./src/main/resources/static/css/tailwind.css --watch"
 
 networks:
   tabisketch:


### PR DESCRIPTION
## 関連する
- #281 

node:22-alpine のコンテナの中で

```
npx tailwindcss -i ./src/main/resources/static/css/input.css -o ./src/main/resources/static/css/tailwind.css --watch
```

を実行する docker compose のサービスを追加

```
docker compose up
```

しておくと、tailwindcss が input.css を watch モードで監視して input.css に変更があれば、即座に tailwind.css を再生成する